### PR TITLE
dstore: Fix access rights for sm segments

### DIFF
--- a/src/dstore/pmix_esh.c
+++ b/src/dstore/pmix_esh.c
@@ -1658,9 +1658,9 @@ static seg_desc_t *_create_new_segment(segment_type type, const ns_map_data_t *n
         }
         memset(new_seg->seg_info.seg_base_addr, 0, size);
 
-        if (_setjobuid > 0){
+        if (_ESH_SESSION_setjobuid(ns_map->tbl_idx) > 0){
             rc = PMIX_ERR_NO_PERMISSIONS;
-            if (0 > chown(file_name, (uid_t) _jobuid, (gid_t) -1)){
+            if (0 > chown(file_name, (uid_t) _ESH_SESSION_jobuid(ns_map->tbl_idx), (gid_t) -1)){
                 PMIX_ERROR_LOG(rc);
                 goto err_exit;
             }


### PR DESCRIPTION
Change the access rights in accordance to session info

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit a699abf3aed703d977af65b1687ccdf3f742cbbd)

Conflicts:
	src/dstore/pmix_esh.c