### PR TITLE
Fixed possible crash due to use uninitialized `ninfo`

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3534,6 +3534,8 @@ static void cdcon(pmix_server_caddy_t *cd)
     cd->event_active = false;
     cd->trk = NULL;
     cd->peer = NULL;
+    cd->info = NULL;
+    cd->ninfo = 0;
 }
 static void cddes(pmix_server_caddy_t *cd)
 {


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>